### PR TITLE
Work around permission related errors when running as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN JULIA_DEPOT_PATH=/usr/local/share/julia \
               Pkg.add([PackageSpec(name="CUDAapi",      rev="v1.1.0"), \
                        PackageSpec(name="CUDAdrv",      rev="v3.1.0"), \
                        PackageSpec(name="CUDAnative",   rev="v2.3.0"), \
-                       PackageSpec(name="CuArrays",     rev="v1.2.1")]);'
-
+                       PackageSpec(name="CuArrays",     rev="v1.2.1")]);' && \
+    find /usr/local/share/julia/packages -maxdepth 2 -mindepth 2 -exec chmod 0755 {} \;
 
 # user environment
 
@@ -32,7 +32,7 @@ RUN JULIA_DEPOT_PATH=/usr/local/share/julia \
 #
 # the actual modification of DEPOT_PATH happens in startup.jl
 
-VOLUME ["/data"]
+RUN mkdir -m 0777 /data
 
 ENV JULIA_HISTORY=/data/logs/repl_history.jl
 


### PR DESCRIPTION
Addresses #1 and #2 (partially).

Non-root users were unable to access the CUDA packages in the depot.  Manually chmod all the depot packages to ensure they are readable.

Also, if the `/data` volume was not mounted, then non-root users would get errors about `/data` not being writable.  Instead of a `VOLUME`, just create a directory writable by anyone.  A host directory can still be mounted over this location for persistence.

In the Singularity case, even with the open permissions on `/data`, it still fails because the image is read-only.  A host directory must be mounted inside the container for it to be successful, e.g., `singularity run --nv -B $HOME/.julia-ngc:/data julia.sif`.